### PR TITLE
Bump alteamc/minequery to v1.1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/vert3xo/mcscan
 go 1.17
 
 require (
-	github.com/alteamc/minequery v1.1.5
+	github.com/alteamc/minequery v1.1.6
 	github.com/hibiken/asynq v0.23.0
 	github.com/joho/godotenv v1.4.0
 	github.com/zan8in/masscan v0.0.0-20220427061403-88ba387d5740

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/alteamc/minequery v1.1.5 h1:B33poEF6onbgOMMvHRngy70zQ6PyIe5nS7sJFEcFEcE=
-github.com/alteamc/minequery v1.1.5/go.mod h1:kvUqK4oK/3fzvqj5601CNomxIorXJJePRpXEEmWFBqU=
+github.com/alteamc/minequery v1.1.6 h1:G2dC0BKww7ltpVmVCdFsLOZ5Ac2Y5BENmMCyrs9S9hU=
+github.com/alteamc/minequery v1.1.6/go.mod h1:kvUqK4oK/3fzvqj5601CNomxIorXJJePRpXEEmWFBqU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=


### PR DESCRIPTION
Hello! v1.1.5 of alteamc/minequery has a bug described in alteamc/minequery#23 and may block the calling goroutine on ping; I'd suggest you upgrading to v1.1.6 so that your project works as intended.

https://github.com/vert3xo/mcscan/blob/85251246d7462aca07ec94646a7c687124dd79df/tasks/task.go#L105
